### PR TITLE
Re-run getimagesize without source_info if false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+vendor
+composer.lock

--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -77,7 +77,9 @@ class ImageResize
 			throw new ImageResizeException('Unsupported file type');
 		}
 		
-        $image_info = getimagesize($filename,$this->source_info);
+        if (!$image_info = getimagesize($filename, $this->source_info)) {
+            $image_info = getimagesize($filename);
+        }
 
         if (!$image_info) {
             throw new ImageResizeException('Could not read file');


### PR DESCRIPTION
Certain JPG images fail to get the $image_info variable when
$this->source_info is set in the getimagesize function if the exif data
is not what PHP is expecting. This ends up throwing exceptions instead
of letting them through as though they do not have exif data.

To allow valid images to make it through, we need to check to see if we
can retreive $image_info via getimagesize WITH $this->source_info, if
not (getimagesize returns FALSE), then get the $image_info without the
$this->source_info. Then it will fall back to throwing the
ImageResizeException if it still does not exist.