### PR TITLE
Prevent exif_read_data() warning propagation through custom error handler

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -2,6 +2,8 @@
 
 namespace Gumlet;
 
+use Exception;
+
 /**
  * PHP class to resize and scale images
  */
@@ -171,7 +173,11 @@ class ImageResize
             return $img;
         }
 
-        $exif = @exif_read_data($filename);
+        try {
+            $exif = @exif_read_data($filename);
+        } catch (Exception $e) {
+            $exif = null;
+        }
 
         if (!$exif || !isset($exif['Orientation'])) {
             return $img;


### PR DESCRIPTION
Wrap `@exif_read_data()` in a try/catch to prevent some subtle bug when there's a custom error handler that does not read and respect `error_reporting()`.

See issue #114.