### PR TITLE
Support RFC 2397 data urls

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -105,7 +105,7 @@ class ImageResize
         if (!defined('IMAGETYPE_WEBP')) {
             define('IMAGETYPE_WEBP', 18);
         }
-        if ($filename === null || empty($filename) || (substr($filename, 0, 7) !== 'data://' && !is_file($filename))) {
+        if ($filename === null || empty($filename) || (substr($filename, 0, 5) !== 'data:' && !is_file($filename))) {
             throw new ImageResizeException('File does not exist');
         }
 

--- a/test/ImageResizeTest.php
+++ b/test/ImageResizeTest.php
@@ -15,6 +15,7 @@ class ImageResizeTest extends TestCase
 
     private $unsupported_image = 'Qk08AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABAAAAAAAAYAAAASCwAAEgsAAAAAAAAAAAAA/38AAAAA';
     private $image_string = 'R0lGODlhAQABAIAAAAQCBP///yH5BAEAAAEALAAAAAABAAEAAAICRAEAOw==';
+    private $data_url = 'data:image/gif;base64,R0lGODlhAQABAIAAAAQCBP///yH5BAEAAAEALAAAAAABAAEAAAICRAEAOw==';
 
 
     /**
@@ -63,6 +64,14 @@ class ImageResizeTest extends TestCase
 
         $this->assertEquals(IMAGETYPE_GIF, $resize->source_type);
         $this->assertInstanceOf('\Gumlet\ImageResize', $resize);
+    }
+
+    public function testLoadRfc2397()
+    {
+      $resize = new ImageResize($this->data_url);
+
+      $this->assertEquals(IMAGETYPE_GIF, $resize->source_type);
+      $this->assertInstanceOf('\Gumlet\ImageResize', $resize);
     }
 
     public function testAddFilter()


### PR DESCRIPTION
PHP can parse both "data://" and "data:" url schemas. It would be handy to have support for the latter ([RFC2397](https://tools.ietf.org/html/rfc2397)) in ImageResize, as JS constructed data urls use that schema.