### PR TITLE
add gamma correct option

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,15 @@ $flip->imageFlip($image, 0);
 
 Both functions will be used in the order in which they were added.
 
+Gamma color correction
+--------
+
+You can disable the gamma color correction enabled by default.
+
+```php
+$image = new ImageResize('image.png');
+$image->gamma(false);
+```
 
 API Doc
 -------

--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -24,6 +24,7 @@ class ImageResize
     public $quality_webp = 85;
     public $quality_png = 6;
     public $quality_truecolor = true;
+    public $gamma_correct = true;
 
     public $interlace = 1;
 
@@ -48,8 +49,6 @@ class ImageResize
 
     protected $source_info;
     
-    protected $gamma_correct = true;
-
     protected $filters = [];
 
     /**

--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -47,7 +47,8 @@ class ImageResize
     protected $source_h;
 
     protected $source_info;
-
+    
+    protected $gamma_correct = true;
 
     protected $filters = [];
 
@@ -286,7 +287,9 @@ class ImageResize
 
         imageinterlace($dest_image, $this->interlace);
 
-        imagegammacorrect($this->source_image, 2.2, 1.0);
+        if ($this->gamma_correct) {
+            imagegammacorrect($this->source_image, 2.2, 1.0);
+        }
 
         if( !empty($exact_size) && is_array($exact_size) ) {
             if ($this->getSourceHeight() < $this->getSourceWidth()) {
@@ -312,7 +315,9 @@ class ImageResize
             $this->source_h
         );
         
-        imagegammacorrect($dest_image, 1.0, 2.2);
+        if ($this->gamma_correct) {
+            imagegammacorrect($dest_image, 1.0, 2.2);
+        }
 
 
         $this->applyFilter($dest_image);

--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -760,4 +760,17 @@ class ImageResize
         }
         imagedestroy($temp_image);
     }
+
+    /**
+     * Enable or not the gamma color correction on the image, enabled by default
+     *
+     * @param bool $enable
+     * @return static
+     */
+    public function gamma($enable = true)
+    {
+        $this->gamma_correct = $enable;
+
+        return $this;
+    }
 }


### PR DESCRIPTION
With a new option on the main class, we will able to tell if we want gamma correction.

When you use this library and rescale a image, the image's colors tends to not be keeped, this is caused by the image gamma correction applied before and after the proccessing.