### PR TITLE
Handle alpha for webp if source have alpha

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -267,6 +267,10 @@ class ImageResize
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
             }
+                
+            imagealphablending($dest_image, false);
+            imagesavealpha($dest_image, true);
+                
             break;
 
         case IMAGETYPE_PNG:


### PR DESCRIPTION
If the source file is a png, then we can keep the alpha for saving in webp format.