### PR TITLE
More Float to Int Casting

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -226,7 +226,7 @@ class ImageResize
             if( !empty($exact_size) && is_array($exact_size) ){
                 $dest_image = imagecreatetruecolor($exact_size[0], $exact_size[1]);
             } else{
-                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                $dest_image = imagecreatetruecolor((int) $this->getDestWidth(), (int) $this->getDestHeight());
             }
 
             $background = imagecolorallocatealpha($dest_image, 255, 255, 255, 1);
@@ -253,9 +253,9 @@ class ImageResize
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $exact_size[0], $exact_size[1], $background);
             } else{
-                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                $dest_image = imagecreatetruecolor((int) $this->getDestWidth(), (int) $this->getDestHeight());
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
-                imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
+                imagefilledrectangle($dest_image, 0, 0, (int) $this->getDestWidth(), (int) $this->getDestHeight(), $background);
             }
                 
             imagealphablending($dest_image, false);
@@ -269,9 +269,9 @@ class ImageResize
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $exact_size[0], $exact_size[1], $background);
             } else{
-                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                $dest_image = imagecreatetruecolor((int) $this->getDestWidth(), (int) $this->getDestHeight());
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
-                imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
+                imagefilledrectangle($dest_image, 0, 0, (int) $this->getDestWidth(), (int) $this->getDestHeight(), $background);
             }
                 
             imagealphablending($dest_image, false);
@@ -284,13 +284,13 @@ class ImageResize
                 if( !empty($exact_size) && is_array($exact_size) ){
                     $dest_image = imagecreate($exact_size[0], $exact_size[1]);
                 } else{
-                    $dest_image = imagecreate($this->getDestWidth(), $this->getDestHeight());
+                    $dest_image = imagecreate((int) $this->getDestWidth(), (int) $this->getDestHeight());
                 }
             } else {
                 if( !empty($exact_size) && is_array($exact_size) ){
                     $dest_image = imagecreatetruecolor($exact_size[0], $exact_size[1]);
                 } else{
-                    $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                    $dest_image = imagecreatetruecolor((int) $this->getDestWidth(), (int) $this->getDestHeight());
                 }
             }
 
@@ -308,9 +308,9 @@ class ImageResize
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
                 imagefilledrectangle($dest_image, 0, 0, $exact_size[0], $exact_size[1], $background);
             } else {
-                $dest_image = imagecreatetruecolor($this->getDestWidth(), $this->getDestHeight());
+                $dest_image = imagecreatetruecolor((int) $this->getDestWidth(), (int) $this->getDestHeight());
                 $background = imagecolorallocate($dest_image, 255, 255, 255);
-                imagefilledrectangle($dest_image, 0, 0, $this->getDestWidth(), $this->getDestHeight(), $background);
+                imagefilledrectangle($dest_image, 0, 0, (int) $this->getDestWidth(), (int) $this->getDestHeight(), $background);
             }
             break;
         }


### PR DESCRIPTION
We had a few more less-frequent logs come through, so I figured it made sense to just cast the rest of these to integers when the function they're being passed into expects an integer. 
Might as well be consistently with it throughout the file.

Current functionality casts it to an int implicitly, which cuts off the float tail. Casting it explicitly still cuts off the float tail, but avoids the warning about implicit conversion. So, the functionality will remain the same.